### PR TITLE
Fix warning X4000: use of potentially uninitialized variable

### DIFF
--- a/Shaders/StencilDebug.compute
+++ b/Shaders/StencilDebug.compute
@@ -35,12 +35,14 @@ static uint bits[5] = {
 // https://gist.github.com/FreyaHolmer/71717be9f3030c1b0990d3ed1ae833e3
 float draw_digit(int2 px, const int digit)
 {
-    if (px.x < 0 || px.x > 2 || px.y < 0 || px.y > 4) {
+    if (px.x < 0 || px.x > 2 || px.y < 0 || px.y > 4)
         return 0;
+    // unnecessary else to calm down hlsl compiler warning X4000: use of potentially uninitialized variable 
+    else
+    {
+        const int id = digit == -1 ? 18 : 31 - (3 * digit + px.x);
+        return (bits[4 - px.y] & 1 << id) != 0;
     }
-
-    const int id = digit == -1 ? 18 : 31 - (3 * digit + px.x);
-    return (bits[4 - px.y] & 1 << id) != 0;
 }
 
 [numthreads(8, 8, 1)]


### PR DESCRIPTION
In unity 6 on Vulkan graphics API there is a warning: `Shader warning in 'StencilDebug': use of potentially uninitialized variable (draw_digit) at kernel StencilDebug at StencilDebug.compute(39) (on vulkan)` which happens because hlsl compiler is crazy and doesn't understand next code structure
```hlsl
if(predicate)
    return x;
return y;
```
It wants instead
```hlsl
if(predicate)
    return x;
else 
    return y;
```